### PR TITLE
Various fixes

### DIFF
--- a/lib/github/authentication/generator/app.rb
+++ b/lib/github/authentication/generator/app.rb
@@ -33,9 +33,9 @@ module Github
         def jwt
           payload = {
             # issued at time
-            iat: Time.now.to_i,
+            iat: Time.now.utc.to_i,
             # JWT expiration time (10 minute maximum)
-            exp: Time.now.to_i + (10 * 60),
+            exp: Time.now.utc.to_i + (10 * 60),
             # GitHub App's identifier
             iss: app_id,
           }

--- a/lib/github/authentication/generator/personal.rb
+++ b/lib/github/authentication/generator/personal.rb
@@ -11,7 +11,7 @@ module Github
         end
 
         def generate
-          a_year_from_now = Time.now + 31_556_952
+          a_year_from_now = Time.now.utc + 31_556_952
           Token.new(@github_token, a_year_from_now)
         end
       end

--- a/lib/github/authentication/object_cache.rb
+++ b/lib/github/authentication/object_cache.rb
@@ -13,7 +13,7 @@ module Github
         return unless @cache.has_key?(key)
 
         options = @cache[key][:options]
-        if options.has_key?(:expires_at) && Time.now > options[:expires_at]
+        if options.has_key?(:expires_at) && Time.now.utc > options[:expires_at]
           @cache.delete(key)
           return nil
         end
@@ -23,7 +23,7 @@ module Github
 
       def write(key, value, options = {})
         if options.has_key?(:expires_in)
-          options[:expires_at] = Time.now + options[:expires_in] * 60
+          options[:expires_at] = Time.now.utc + options[:expires_in] * 60
         end
         @cache[key] = { value: value, options: options }
       end

--- a/lib/github/authentication/provider.rb
+++ b/lib/github/authentication/provider.rb
@@ -14,6 +14,7 @@ module Github
 
       def initialize(generator:, cache:)
         super()
+        @token = nil
         @generator = generator
         @cache = cache
       end

--- a/lib/github/authentication/token.rb
+++ b/lib/github/authentication/token.rb
@@ -22,11 +22,11 @@ module Github
       end
 
       def expires_in
-        (@expires_at - Time.now).to_i / 60
+        (@expires_at - Time.now.utc).to_i / 60
       end
 
       def expired?(seconds_ttl: 300)
-        @expires_at < Time.now + seconds_ttl
+        @expires_at < Time.now.utc + seconds_ttl
       end
 
       def valid_for?(ttl)

--- a/test/github/authentication/cache_test.rb
+++ b/test/github/authentication/cache_test.rb
@@ -7,7 +7,7 @@ module Github
   module Authentication
     class CacheTest < Minitest::Test
       def setup
-        Timecop.freeze(Time.local(1990))
+        Timecop.freeze("1990-01-01T00:00:00Z")
         @key = "github:authentication:foo"
       end
 
@@ -17,7 +17,7 @@ module Github
 
       def test_read_from_cache
         storage = mock()
-        storage.stubs(:read).with(@key).returns('{"token":"foo","expires_at":"1990-01-01T00:00:00+00:00"}')
+        storage.stubs(:read).with(@key).returns('{"token":"foo","expires_at":"1990-01-01T00:00:00Z"}')
         cache = Cache.new(key: 'foo', storage: storage)
 
         token = cache.read
@@ -29,9 +29,9 @@ module Github
       def test_write_to_cache
         storage = mock()
         storage.stubs(:write)
-          .with(@key, '{"token":"foo","expires_at":"1990-01-01T00:00:00+00:00"}', expires_in: 0)
+          .with(@key, '{"token":"foo","expires_at":"1990-01-01T00:00:00Z"}', expires_in: 0)
         cache = Cache.new(key: 'foo', storage: storage)
-        token = Token.new('foo', Time.now)
+        token = Token.new('foo', Time.now.utc)
 
         cache.write(token)
       end

--- a/test/github/authentication/generator/personal_test.rb
+++ b/test/github/authentication/generator/personal_test.rb
@@ -8,7 +8,7 @@ module Github
     module Generator
       class PersonalTest < Minitest::Test
         def setup
-          Timecop.freeze(Time.local(1990))
+          Timecop.freeze("1990-01-01T00:00:00Z")
         end
 
         def after
@@ -20,7 +20,7 @@ module Github
 
           token = generator.generate
 
-          assert_equal '1991-01-01T05:49:12+00:00', token.expires_at.iso8601
+          assert_equal '1991-01-01T05:49:12Z', token.expires_at.iso8601
           assert_equal 'foo', token.to_s
         end
       end

--- a/test/github/authentication/object_cache_test.rb
+++ b/test/github/authentication/object_cache_test.rb
@@ -5,7 +5,7 @@ require 'github/authentication/object_cache'
 
 module Github
   module Authentication
-    class CacheTest < Minitest::Test
+    class ObjectCacheTest < Minitest::Test
       def setup
         Timecop.freeze("1990-01-01T00:00:00Z")
         @key = "github:authentication:foo"
@@ -45,7 +45,7 @@ module Github
         end
       end
 
-      def test_read_from_cache_is_not_expired
+      def test_read_from_cache_is_not_expired_2
         cache = ObjectCache.new
 
         cache.write('foo', 'bar')

--- a/test/github/authentication/object_cache_test.rb
+++ b/test/github/authentication/object_cache_test.rb
@@ -45,7 +45,7 @@ module Github
         end
       end
 
-      def test_read_from_cache_is_not_expired_2
+      def test_read_from_cache_is_never_expired
         cache = ObjectCache.new
 
         cache.write('foo', 'bar')
@@ -58,4 +58,3 @@ module Github
     end
   end
 end
-

--- a/test/github/authentication/object_cache_test.rb
+++ b/test/github/authentication/object_cache_test.rb
@@ -7,7 +7,7 @@ module Github
   module Authentication
     class CacheTest < Minitest::Test
       def setup
-        Timecop.freeze(Time.local(1990))
+        Timecop.freeze("1990-01-01T00:00:00Z")
         @key = "github:authentication:foo"
       end
 

--- a/test/github/authentication/token_test.rb
+++ b/test/github/authentication/token_test.rb
@@ -7,7 +7,7 @@ module Github
   module Authentication
     class TokenTest < Minitest::Test
       def setup
-        Timecop.freeze(Time.local(1990))
+        Timecop.freeze("1990-01-01T00:00:00Z")
       end
 
       def teardown
@@ -21,56 +21,56 @@ module Github
       end
 
       def test_from_json_returns_token_object
-        result = Token.from_json('{"token":"foo","expires_at":"1990-01-01T00:00:00+00:00"}')
+        result = Token.from_json('{"token":"foo","expires_at":"1990-01-01T00:00:00Z"}')
 
         assert_equal 'foo', result.to_s
-        assert_equal Time.now, result.expires_at
+        assert_equal Time.now.utc, result.expires_at
       end
 
       def test_expires_in_returns_correct_number
-        token = Token.new('foo', Time.now + 20*60)
+        token = Token.new('foo', Time.now.utc + 20*60)
 
         assert_equal 20, token.expires_in
       end
 
       def test_expired_returns_true_when_expired
-        token = Token.new('foo', Time.now + 3*60)
+        token = Token.new('foo', Time.now.utc + 3*60)
 
         assert token.expired?
       end
 
       def test_expired_returns_false_when_not_expired
-        token = Token.new('foo', Time.now + 10*60)
+        token = Token.new('foo', Time.now.utc + 10*60)
 
         refute token.expired?
       end
 
       def test_valid_for_returns_false_when_invalid
-        token = Token.new('foo', Time.now + 10*60)
+        token = Token.new('foo', Time.now.utc + 10*60)
 
         assert token.valid_for?(9*60)
       end
 
       def test_valid_for_returns_true_when_valid
-        token = Token.new('foo', Time.now + 10*60)
+        token = Token.new('foo', Time.now.utc + 10*60)
 
         refute token.valid_for?(11*60)
       end
 
       def test_inspect
-        token = Token.new('foooooooooooof', Time.now)
+        token = Token.new('foooooooooooof', Time.now.utc)
 
-        assert_equal '#<Github::Authentication::Token @token=fooooooooo... @expires_at=1990-01-01 00:00:00 +0000>', token.inspect
+        assert_equal '#<Github::Authentication::Token @token=fooooooooo... @expires_at=1990-01-01 00:00:00 UTC>', token.inspect
       end
 
       def test_to_json
-        token = Token.new('foo', Time.now)
+        token = Token.new('foo', Time.now.utc)
 
-        assert_equal '{"token":"foo","expires_at":"1990-01-01T00:00:00+00:00"}', token.to_json
+        assert_equal '{"token":"foo","expires_at":"1990-01-01T00:00:00Z"}', token.to_json
       end
 
       def test_to_s_and_to_str
-        token = Token.new('foo', Time.now)
+        token = Token.new('foo', Time.now.utc)
 
         assert_equal 'foo', token.to_s
         assert_equal 'foo', token.to_str


### PR DESCRIPTION
- Always use `Time#utc` to make sure we don’t run into weird timezone and DST issues.
- Fix some duplicate names that were causing warnings (and bugs)
- Fix a Ruby warning.