### PR TITLE
Provider: fix variable name bug

### DIFF
--- a/lib/github/authentication/provider.rb
+++ b/lib/github/authentication/provider.rb
@@ -25,7 +25,7 @@ module Github
           mu_synchronize do
             return @token if @token&.valid_for?(seconds_ttl)
 
-            if (token = @cache.read)
+            if (@token = @cache.read)
               return @token if @token.valid_for?(seconds_ttl)
             end
 


### PR DESCRIPTION
We need to assign the token to the instance variable, rather than a local variable. 
The local variable was never used, so cache reads were basically doing nothing. 
This caused one of the tests to fail.