### PR TITLE
Improve resiliency and error handling of HTTP requests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,3 +16,5 @@ Style/MethodCallWithArgsParentheses:
     - refute_equal
     - assert_nil
     - refute_nil
+    - assert_kind_of
+    - refute_kind_of

--- a/lib/github/authentication/http.rb
+++ b/lib/github/authentication/http.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'net/http'
+require 'timeout'
 
 require 'github/authentication/retriable'
 
@@ -14,7 +15,7 @@ module Github
           uri = URI.parse(url)
           http = nil
 
-          result = with_retries(Errno::ECONNREFUSED, Net::ReadTimeout) do
+          result = with_retries(SystemCallError, Timeout::Error) do
             unless http
               http = Net::HTTP.new(uri.host, uri.port)
               http.use_ssl = true

--- a/lib/github/authentication/http.rb
+++ b/lib/github/authentication/http.rb
@@ -13,21 +13,20 @@ module Github
 
         def post(url)
           uri = URI.parse(url)
-          http = nil
+          with_retries(SystemCallError, Timeout::Error) do
+            http = Net::HTTP.new(uri.host, uri.port)
+            http.use_ssl = true
+            http.start
+            begin
 
-          result = with_retries(SystemCallError, Timeout::Error) do
-            unless http
-              http = Net::HTTP.new(uri.host, uri.port)
-              http.use_ssl = true
-              http.start
+              request = Net::HTTP::Post.new(uri.request_uri)
+              yield(request) if block_given?
+
+              http.request(request)
+            ensure
+              http.finish
             end
-            request = Net::HTTP::Post.new(uri.request_uri)
-            yield(request) if block_given?
-            http.request(request)
           end
-
-          http&.finish
-          result
         end
       end
     end

--- a/test/github/authentication/provider_test.rb
+++ b/test/github/authentication/provider_test.rb
@@ -37,9 +37,9 @@ module Github
 
       def test_token_not_present_generates_invalid_token_tries_again
         valid_token = mock
-        valid_token.stubs(:valid_for?).returns(false)
+        valid_token.stubs(:valid_for?).returns(true)
         invalid_token = mock
-        invalid_token.stubs(:valid_for?).returns(true)
+        invalid_token.stubs(:valid_for?).returns(false)
         generator = mock
         generator.stubs(:generate).returns(invalid_token).then.returns(valid_token)
         cache = mock
@@ -48,7 +48,6 @@ module Github
         provider = Provider.new(generator: generator, cache: cache)
 
         result = provider.token
-
         assert result.valid_for?
       end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,3 +12,10 @@ VCR.configure do |config|
   config.cassette_library_dir = "test/fixtures/vcr_cassettes"
   config.hook_into(:webmock)
 end
+
+Mocha.configure do |c|
+  c.stubbing_method_on_non_mock_object = :allow
+  c.stubbing_method_unnecessarily = :prevent
+  c.stubbing_method_on_nil = :prevent
+  c.stubbing_non_existent_method = :prevent
+end


### PR DESCRIPTION
Rescue more generic exceptions when doing HTTP calls. Besides `Net::ReadTimeout`, we can also have a `Net::OpenTimeout`. Both are subclasses of `Timeout::Error`, so let's retry the superclass. Also, there are many other Errno exceptions that can occur when doing IO. All of them should be retried. `SystemCallError` wraps all of them.

Also, don’t keep the HTTP connection around between retries. Requests may be failing because the connection is bad. So whenever the retry mechanism kicks in, we should always create a new connection to give us the highest likelihood it will work during retry.