### PR TITLE
Active support cache fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    github-authentication (0.1.0)
+    github-authentication (0.1.2)
       jwt (~> 2.2)
 
 GEM

--- a/lib/github/authentication/object_cache.rb
+++ b/lib/github/authentication/object_cache.rb
@@ -23,7 +23,7 @@ module Github
 
       def write(key, value, options = {})
         if options.key?(:expires_in)
-          options[:expires_at] = Time.now.utc + options[:expires_in] * 60
+          options[:expires_at] = Time.now.utc + options[:expires_in]
         end
         @cache[key] = { value: value, options: options }
       end

--- a/lib/github/authentication/token.rb
+++ b/lib/github/authentication/token.rb
@@ -22,7 +22,7 @@ module Github
       end
 
       def expires_in
-        (@expires_at - Time.now.utc).to_i / 60
+        (@expires_at - Time.now.utc).to_i
       end
 
       def expired?(seconds_ttl: 300)

--- a/lib/github/authentication/version.rb
+++ b/lib/github/authentication/version.rb
@@ -2,6 +2,6 @@
 
 module Github
   module Authentication
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end

--- a/test/github/authentication/object_cache_test.rb
+++ b/test/github/authentication/object_cache_test.rb
@@ -26,7 +26,7 @@ module Github
       def test_read_from_cache_returns_nil_if_expired
         cache = ObjectCache.new
 
-        cache.write('foo', 'bar', expires_in: 10)
+        cache.write('foo', 'bar', expires_in: 10 * 60) # 10 minutes
         Timecop.freeze(Time.now + 11 * 60) do
           result = cache.read('foo')
 
@@ -37,7 +37,7 @@ module Github
       def test_read_from_cache_is_not_expired
         cache = ObjectCache.new
 
-        cache.write('foo', 'bar', expires_in: 10)
+        cache.write('foo', 'bar', expires_in: 10 * 60) # 10 minutes
         Timecop.freeze(Time.now + 9 * 60) do
           result = cache.read('foo')
 

--- a/test/github/authentication/token_test.rb
+++ b/test/github/authentication/token_test.rb
@@ -28,9 +28,9 @@ module Github
       end
 
       def test_expires_in_returns_correct_number
-        token = Token.new('foo', Time.now + 20 * 60)
+        token = Token.new('foo', Time.now + 10 * 60) # 10 minutes
 
-        assert_equal 20, token.expires_in
+        assert_equal 600, token.expires_in
       end
 
       def test_expired_returns_true_when_expired


### PR DESCRIPTION
The [expires_in](https://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html#method-i-fetch) option expects the number of **seconds** to automatically expire a cache entry, instead of the number of **minutes**. The `expires_in` attribute is forwarded to the concrete Store implementation (e.g. Redis).

This PR adjusts the `Token` and `ObjectCache` classes to provide and use `expires_in` with seconds instead of minutes, making it compatible with ActiveSupport::Cache::Store.
