### PR TITLE
Release v1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    github-authentication (0.2.1)
+    github-authentication (1.0.0)
       jwt (~> 2.2)
 
 GEM

--- a/lib/github_authentication/version.rb
+++ b/lib/github_authentication/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GithubAuthentication
-  VERSION = "0.2.1"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
#11 is a breaking API change, meaning version specifiers using `~> 0.1` would pull the 0.2 versions and break. I have yanked the 0.2.1 release, this will publish a v1.0 to correctly reflect the breaking API change.