### PR TITLE
Require active_support before extensions

### DIFF
--- a/exe/git-credential-github-app
+++ b/exe/git-credential-github-app
@@ -4,6 +4,7 @@
 require 'github_authentication'
 
 begin
+  require 'active_support'
   require 'active_support/cache'
   require 'active_support/notifications'
 rescue LoadError


### PR DESCRIPTION
Activesupport 7 is breaking due to failure to load transitive dependency in a submodule. [This issue](https://github.com/ruby-grape/grape/issues/2205) outlines the need to require the base `active_support` before including other extensions.