### PR TITLE
Need bundle update when bumping gem version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    github-authentication (1.0.1)
+    github-authentication (1.0.2)
       jwt (~> 2.2)
 
 GEM
@@ -23,7 +23,7 @@ GEM
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
-    jwt (2.2.3)
+    jwt (2.3.0)
     minitest (5.14.0)
     mocha (1.11.2)
     parallel (1.19.1)


### PR DESCRIPTION
Failure to run bundle update when bumping the version [breaks the build](https://shipit.shopify.io/shopify/github-authentication/rubygems/deploys/1484600). Sorry I didn't see this the first time around.