### PR TITLE
Remove graduated GitHub v3 API preview header

### DIFF
--- a/lib/github_authentication/generator/app.rb
+++ b/lib/github_authentication/generator/app.rb
@@ -21,7 +21,7 @@ module GithubAuthentication
         url = "https://api.github.com/app/installations/#{installation_id}/access_tokens"
         response = Http.post(url) do |request|
           request["Authorization"] = "Bearer #{jwt}"
-          request["Accept"] = "application/vnd.github.machine-man-preview+json"
+          request["Accept"] = "application/vnd.github+json"
           request
         end
 


### PR DESCRIPTION
GitHub Developer v3 API announcement:
https://developer.github.com/changes/2020-08-20-graduate-machine-man-and-sailor-v-previews/

The machineman preview has graduated and should be removed.