### PR TITLE
Transparent support for multi-org

### DIFF
--- a/exe/git-credential-github-app
+++ b/exe/git-credential-github-app
@@ -14,11 +14,16 @@ end
 
 case ARGV[0]
 when "get"
+  description = $stdin.each_line.map { |line| line.split("=", 2).map(&:strip) }.to_h
+  org = description.fetch("path", "").split("/").first
+  environment = GithubAuthentication::Environment.new(org: org)
+
   exit_status = GithubAuthentication::GitCredentialHelper.new(
-    pem: File.read(ENV.fetch("GITHUB_APP_KEYFILE")),
-    app_id: ENV.fetch("GITHUB_APP_ID"),
-    installation_id: ENV.fetch("GITHUB_APP_INSTALLATION_ID"),
-    storage: ActiveSupport::Cache::FileStore.new(ENV.fetch("GITHUB_APP_CREDENTIAL_STORAGE_PATH")),
+    pem: environment.pem,
+    app_id: environment.app_id,
+    installation_id: environment.installation_id,
+    storage: environment.storage,
+    description: description,
   ).handle_get
   exit(exit_status)
 when "store"

--- a/lib/github_authentication.rb
+++ b/lib/github_authentication.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "github_authentication/version"
+require "github_authentication/environment"
 require "github_authentication/generator"
 require "github_authentication/provider"
 require "github_authentication/cache"

--- a/lib/github_authentication/environment.rb
+++ b/lib/github_authentication/environment.rb
@@ -21,7 +21,7 @@ module GithubAuthentication
     end
 
     def storage
-      resolve("GITHUB_APP_CREDENTIAL_STORAGE_PATH")
+      ActiveSupport::Cache::FileStore.new(resolve("GITHUB_APP_CREDENTIAL_STORAGE_PATH"))
     end
 
     private

--- a/lib/github_authentication/environment.rb
+++ b/lib/github_authentication/environment.rb
@@ -4,8 +4,9 @@ require "active_support/core_ext/object/blank.rb"
 
 module GithubAuthentication
   class Environment
-    def initialize(org:)
+    def initialize(org:, env: ENV)
       @org = org.presence
+      @env = env
     end
 
     def pem
@@ -28,9 +29,9 @@ module GithubAuthentication
 
     def resolve(suffix)
       if @org
-        ENV["#{@org.upcase}_#{suffix}"] || ENV.fetch(suffix)
+        @env["#{@org.upcase}_#{suffix}"] || @env.fetch(suffix)
       else
-        ENV.fetch(suffix)
+        @env.fetch(suffix)
       end
     end
   end

--- a/lib/github_authentication/environment.rb
+++ b/lib/github_authentication/environment.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/object/blank.rb"
+
+module GithubAuthentication
+  class Environment
+    def initialize(org:)
+      @org = org.presence
+    end
+
+    def pem
+      File.read(resolve("GITHUB_APP_KEYFILE"))
+    end
+
+    def app_id
+      resolve("GITHUB_APP_ID")
+    end
+
+    def installation_id
+      resolve("GITHUB_APP_INSTALLATION_ID")
+    end
+
+    def storage
+      resolve("GITHUB_APP_CREDENTIAL_STORAGE_PATH")
+    end
+
+    private
+
+    def resolve(suffix)
+      if @org
+        ENV["#{@org.upcase}_#{suffix}"] || ENV.fetch(suffix)
+      else
+        ENV.fetch(suffix)
+      end
+    end
+  end
+end

--- a/lib/github_authentication/git_credential_helper.rb
+++ b/lib/github_authentication/git_credential_helper.rb
@@ -2,19 +2,17 @@
 
 module GithubAuthentication
   class GitCredentialHelper
-    def initialize(pem:, installation_id:, app_id:, storage: nil, stdin: $stdin)
+    def initialize(pem:, installation_id:, app_id:, description:, storage: nil)
       @pem = pem
       @installation_id = installation_id
       @app_id = app_id
+      @description = description
       @storage = storage
-      @stdin = stdin
     end
 
     def handle_get
-      description = parse_stdin
-
-      unless description["protocol"] == "https" && description["host"] == "github.com"
-        warn("Unsupported description: #{description}")
+      unless @description["protocol"] == "https" && @description["host"] == "github.com"
+        warn("Unsupported description: #{@description}")
         return 2
       end
 
@@ -30,12 +28,6 @@ module GithubAuthentication
     def min_cache_ttl
       # Tokens are valid for 60 minutes, allow a 10 minute buffer
       10 * 60
-    end
-
-    def parse_stdin
-      # Credential description is written to STDIN in line delimited key=value form,
-      # see https://git-scm.com/docs/git-credential#IOFMT
-      @stdin.each_line.map { |line| line.split("=", 2).map(&:strip) }.to_h
     end
 
     def provider

--- a/test/github_authentication/environment_test.rb
+++ b/test/github_authentication/environment_test.rb
@@ -8,26 +8,10 @@ module GithubAuthentication
     def setup
       @original_env = ENV.to_h
       @org = "shopify"
-      @env = Environment.new(org: @org)
-
-      # Clear any existing environment variables
-      ENV.delete("GITHUB_APP_KEYFILE")
-      ENV.delete("GITHUB_APP_ID")
-      ENV.delete("GITHUB_APP_INSTALLATION_ID")
-      ENV.delete("GITHUB_APP_CREDENTIAL_STORAGE_PATH")
-      ENV.delete("SHOPIFY_GITHUB_APP_KEYFILE")
-      ENV.delete("SHOPIFY_GITHUB_APP_ID")
-      ENV.delete("SHOPIFY_GITHUB_APP_INSTALLATION_ID")
-      ENV.delete("SHOPIFY_GITHUB_APP_CREDENTIAL_STORAGE_PATH")
-    end
-
-    def teardown
-      ENV.replace(@original_env)
     end
 
     def test_org_instance_variable_is_used_for_env_var_resolution
-      env = Environment.new(org: "custom_org")
-      ENV["CUSTOM_ORG_GITHUB_APP_ID"] = "custom_org_id"
+      env = Environment.new(org: "custom_org", env: { "CUSTOM_ORG_GITHUB_APP_ID" => "custom_org_id" })
 
       result = env.app_id
       assert_equal "custom_org_id", result
@@ -35,114 +19,127 @@ module GithubAuthentication
 
     def test_pem_uses_org_specific_env_var_when_available
       create_test_keyfile("test_keyfile.pem") do |path|
-        ENV["SHOPIFY_GITHUB_APP_KEYFILE"] = path
-        result = @env.pem
+        test_env = { "SHOPIFY_GITHUB_APP_KEYFILE" => path }
+        env = Environment.new(org: @org, env: test_env)
+        result = env.pem
         assert_equal "test_key_content", result
       end
     end
 
     def test_pem_falls_back_to_generic_env_var_when_org_specific_not_available
       create_test_keyfile("test_keyfile.pem") do |path|
-        ENV["GITHUB_APP_KEYFILE"] = path
-        result = @env.pem
+        test_env = { "GITHUB_APP_KEYFILE" => path }
+        env = Environment.new(org: @org, env: test_env)
+        result = env.pem
         assert_equal "test_key_content", result
       end
     end
 
     def test_pem_raises_error_when_neither_env_var_is_set
+      env = Environment.new(org: @org, env: {})
       assert_raises(KeyError) do
-        @env.pem
+        env.pem
       end
     end
 
     def test_pem_raises_error_when_file_does_not_exist
-      ENV["SHOPIFY_GITHUB_APP_KEYFILE"] = "nonexistent_file.pem"
+      test_env = { "SHOPIFY_GITHUB_APP_KEYFILE" => "nonexistent_file.pem" }
+      env = Environment.new(org: @org, env: test_env)
 
       assert_raises(Errno::ENOENT) do
-        @env.pem
+        env.pem
       end
     end
 
     def test_app_id_uses_org_specific_env_var_when_available
-      ENV["SHOPIFY_GITHUB_APP_ID"] = "12345"
+      test_env = { "SHOPIFY_GITHUB_APP_ID" => "12345" }
+      env = Environment.new(org: @org, env: test_env)
 
-      result = @env.app_id
+      result = env.app_id
       assert_equal "12345", result
     end
 
     def test_app_id_falls_back_to_generic_env_var_when_org_specific_not_available
-      ENV["GITHUB_APP_ID"] = "67890"
+      test_env = { "GITHUB_APP_ID" => "67890" }
+      env = Environment.new(org: @org, env: test_env)
 
-      result = @env.app_id
+      result = env.app_id
       assert_equal "67890", result
     end
 
     def test_app_id_raises_error_when_neither_env_var_is_set
+      env = Environment.new(org: @org, env: {})
       assert_raises(KeyError) do
-        @env.app_id
+        env.app_id
       end
     end
 
     def test_installation_id_uses_org_specific_env_var_when_available
-      ENV["SHOPIFY_GITHUB_APP_INSTALLATION_ID"] = "11111"
+      test_env = { "SHOPIFY_GITHUB_APP_INSTALLATION_ID" => "11111" }
+      env = Environment.new(org: @org, env: test_env)
 
-      result = @env.installation_id
+      result = env.installation_id
       assert_equal "11111", result
     end
 
     def test_installation_id_falls_back_to_generic_env_var_when_org_specific_not_available
-      ENV["GITHUB_APP_INSTALLATION_ID"] = "22222"
+      test_env = { "GITHUB_APP_INSTALLATION_ID" => "22222" }
+      env = Environment.new(org: @org, env: test_env)
 
-      result = @env.installation_id
+      result = env.installation_id
       assert_equal "22222", result
     end
 
     def test_installation_id_raises_error_when_neither_env_var_is_set
+      env = Environment.new(org: @org, env: {})
       assert_raises(KeyError) do
-        @env.installation_id
+        env.installation_id
       end
     end
 
     def test_storage_uses_org_specific_env_var_when_available
-      ENV["SHOPIFY_GITHUB_APP_CREDENTIAL_STORAGE_PATH"] = "/custom/storage/path"
+      test_env = { "SHOPIFY_GITHUB_APP_CREDENTIAL_STORAGE_PATH" => "/custom/storage/path" }
+      env = Environment.new(org: @org, env: test_env)
 
-      result = @env.storage.cache_path
+      result = env.storage.cache_path
       assert_equal "/custom/storage/path", result
     end
 
     def test_storage_falls_back_to_generic_env_var_when_org_specific_not_available
-      ENV["GITHUB_APP_CREDENTIAL_STORAGE_PATH"] = "/default/storage/path"
+      test_env = { "GITHUB_APP_CREDENTIAL_STORAGE_PATH" => "/default/storage/path" }
+      env = Environment.new(org: @org, env: test_env)
 
-      result = @env.storage.cache_path
+      result = env.storage.cache_path
       assert_equal "/default/storage/path", result
     end
 
     def test_storage_raises_error_when_neither_env_var_is_set
+      env = Environment.new(org: @org, env: {})
       assert_raises(KeyError) do
-        @env.storage
+        env.storage
       end
     end
 
     def test_org_specific_env_vars_take_precedence_over_generic_ones
-      ENV["SHOPIFY_GITHUB_APP_ID"] = "org_specific_id"
-      ENV["GITHUB_APP_ID"] = "generic_id"
+      test_env = { "SHOPIFY_GITHUB_APP_ID" => "org_specific_id", "GITHUB_APP_ID" => "generic_id" }
+      env = Environment.new(org: @org, env: test_env)
 
-      result = @env.app_id
+      result = env.app_id
       assert_equal "org_specific_id", result
     end
 
     def test_case_sensitivity_of_org_name
       # Test that the org name is converted to uppercase when constructing env var names
-      env = Environment.new(org: "MyOrg")
-      ENV["MYORG_GITHUB_APP_ID"] = "myorg_id"
+      test_env = { "MYORG_GITHUB_APP_ID" => "myorg_id" }
+      env = Environment.new(org: "MyOrg", env: test_env)
 
       result = env.app_id
       assert_equal "myorg_id", result
     end
 
     def test_empty_string_org_name_uses_default_env_var
-      env = Environment.new(org: "")
-      ENV["GITHUB_APP_ID"] = "empty_org_id"
+      test_env = { "GITHUB_APP_ID" => "empty_org_id" }
+      env = Environment.new(org: "", env: test_env)
 
       result = env.app_id
       assert_equal "empty_org_id", result

--- a/test/github_authentication/environment_test.rb
+++ b/test/github_authentication/environment_test.rb
@@ -106,14 +106,14 @@ module GithubAuthentication
     def test_storage_uses_org_specific_env_var_when_available
       ENV["SHOPIFY_GITHUB_APP_CREDENTIAL_STORAGE_PATH"] = "/custom/storage/path"
 
-      result = @env.storage
+      result = @env.storage.cache_path
       assert_equal "/custom/storage/path", result
     end
 
     def test_storage_falls_back_to_generic_env_var_when_org_specific_not_available
       ENV["GITHUB_APP_CREDENTIAL_STORAGE_PATH"] = "/default/storage/path"
 
-      result = @env.storage
+      result = @env.storage.cache_path
       assert_equal "/default/storage/path", result
     end
 

--- a/test/github_authentication/environment_test.rb
+++ b/test/github_authentication/environment_test.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "github_authentication/environment"
+
+module GithubAuthentication
+  class EnvironmentTest < Minitest::Test
+    def setup
+      @org = "shopify"
+      @env = Environment.new(org: @org)
+
+      # Clear any existing environment variables
+      ENV.delete("GITHUB_APP_KEYFILE")
+      ENV.delete("GITHUB_APP_ID")
+      ENV.delete("GITHUB_APP_INSTALLATION_ID")
+      ENV.delete("GITHUB_APP_CREDENTIAL_STORAGE_PATH")
+      ENV.delete("SHOPIFY_GITHUB_APP_KEYFILE")
+      ENV.delete("SHOPIFY_GITHUB_APP_ID")
+      ENV.delete("SHOPIFY_GITHUB_APP_INSTALLATION_ID")
+      ENV.delete("SHOPIFY_GITHUB_APP_CREDENTIAL_STORAGE_PATH")
+    end
+
+    def teardown
+      # Clean up any test files created
+      File.delete("test_keyfile.pem") if File.exist?("test_keyfile.pem")
+    end
+
+    def test_org_instance_variable_is_used_for_env_var_resolution
+      env = Environment.new(org: "custom_org")
+      ENV["CUSTOM_ORG_GITHUB_APP_ID"] = "custom_org_id"
+
+      result = env.app_id
+      assert_equal "custom_org_id", result
+    end
+
+    def test_pem_uses_org_specific_env_var_when_available
+      ENV["SHOPIFY_GITHUB_APP_KEYFILE"] = "test_keyfile.pem"
+      create_test_keyfile("test_keyfile.pem")
+
+      result = @env.pem
+      assert_equal "test_key_content", result
+    end
+
+    def test_pem_falls_back_to_generic_env_var_when_org_specific_not_available
+      ENV["GITHUB_APP_KEYFILE"] = "test_keyfile.pem"
+      create_test_keyfile("test_keyfile.pem")
+
+      result = @env.pem
+      assert_equal "test_key_content", result
+    end
+
+    def test_pem_raises_error_when_neither_env_var_is_set
+      assert_raises(KeyError) do
+        @env.pem
+      end
+    end
+
+    def test_pem_raises_error_when_file_does_not_exist
+      ENV["SHOPIFY_GITHUB_APP_KEYFILE"] = "nonexistent_file.pem"
+
+      assert_raises(Errno::ENOENT) do
+        @env.pem
+      end
+    end
+
+    def test_app_id_uses_org_specific_env_var_when_available
+      ENV["SHOPIFY_GITHUB_APP_ID"] = "12345"
+
+      result = @env.app_id
+      assert_equal "12345", result
+    end
+
+    def test_app_id_falls_back_to_generic_env_var_when_org_specific_not_available
+      ENV["GITHUB_APP_ID"] = "67890"
+
+      result = @env.app_id
+      assert_equal "67890", result
+    end
+
+    def test_app_id_raises_error_when_neither_env_var_is_set
+      assert_raises(KeyError) do
+        @env.app_id
+      end
+    end
+
+    def test_installation_id_uses_org_specific_env_var_when_available
+      ENV["SHOPIFY_GITHUB_APP_INSTALLATION_ID"] = "11111"
+
+      result = @env.installation_id
+      assert_equal "11111", result
+    end
+
+    def test_installation_id_falls_back_to_generic_env_var_when_org_specific_not_available
+      ENV["GITHUB_APP_INSTALLATION_ID"] = "22222"
+
+      result = @env.installation_id
+      assert_equal "22222", result
+    end
+
+    def test_installation_id_raises_error_when_neither_env_var_is_set
+      assert_raises(KeyError) do
+        @env.installation_id
+      end
+    end
+
+    def test_storage_uses_org_specific_env_var_when_available
+      ENV["SHOPIFY_GITHUB_APP_CREDENTIAL_STORAGE_PATH"] = "/custom/storage/path"
+
+      result = @env.storage
+      assert_equal "/custom/storage/path", result
+    end
+
+    def test_storage_falls_back_to_generic_env_var_when_org_specific_not_available
+      ENV["GITHUB_APP_CREDENTIAL_STORAGE_PATH"] = "/default/storage/path"
+
+      result = @env.storage
+      assert_equal "/default/storage/path", result
+    end
+
+    def test_storage_raises_error_when_neither_env_var_is_set
+      assert_raises(KeyError) do
+        @env.storage
+      end
+    end
+
+    def test_org_specific_env_vars_take_precedence_over_generic_ones
+      ENV["SHOPIFY_GITHUB_APP_ID"] = "org_specific_id"
+      ENV["GITHUB_APP_ID"] = "generic_id"
+
+      result = @env.app_id
+      assert_equal "org_specific_id", result
+    end
+
+    def test_case_sensitivity_of_org_name
+      # Test that the org name is converted to uppercase when constructing env var names
+      env = Environment.new(org: "MyOrg")
+      ENV["MYORG_GITHUB_APP_ID"] = "myorg_id"
+
+      result = env.app_id
+      assert_equal "myorg_id", result
+    end
+
+    def test_empty_string_org_name_uses_default_env_var
+      env = Environment.new(org: "")
+      ENV["GITHUB_APP_ID"] = "empty_org_id"
+
+      result = env.app_id
+      assert_equal "empty_org_id", result
+    end
+
+    private
+
+    def create_test_keyfile(path)
+      File.write(path, "test_key_content")
+    end
+  end
+end

--- a/test/github_authentication/git_credential_helper_test.rb
+++ b/test/github_authentication/git_credential_helper_test.rb
@@ -13,21 +13,14 @@ module GithubAuthentication
       @pem = File.read("test/fixtures/dummy_private_key.pem")
       @app_id = rand(1000)
       @installation_id = rand(10000)
-      @stdin = StringIO.new
-
-      @helper = GitCredentialHelper.new(
-        pem: @pem,
-        app_id: @app_id,
-        installation_id: @installation_id,
-        stdin: @stdin,
-      )
+      @description = ""
     end
 
     def test_handle_get_prints_credential
-      stub_stdin
+      stub_description
       stub_create_installation_access_token(token: "s3cret")
       out, err = capture_io do
-        assert_predicate @helper.handle_get, :zero?
+        assert_predicate helper.handle_get, :zero?
       end
 
       assert_empty(err)
@@ -35,10 +28,10 @@ module GithubAuthentication
     end
 
     def test_handle_get_errors_on_unknown_host
-      stub_stdin(host: "not.github.com")
+      stub_description(host: "not.github.com")
 
       out, err = capture_io do
-        assert_predicate @helper.handle_get, :nonzero?
+        assert_predicate helper.handle_get, :nonzero?
       end
 
       refute_empty(err)
@@ -47,11 +40,23 @@ module GithubAuthentication
 
     private
 
-    def stub_stdin(protocol: "https", host: "github.com", path: nil)
-      @stdin.write("protocol=#{protocol}\nhost=#{host}\n")
-      @stdin.write("path=#{path}\n") unless path.nil?
+    def helper
+      @helper ||= GitCredentialHelper.new(
+        pem: @pem,
+        app_id: @app_id,
+        installation_id: @installation_id,
+        description: @description,
+      )
+    end
 
-      @stdin.rewind
+    def stub_description(protocol: "https", host: "github.com", path: nil)
+      @description = {
+        "protocol" => protocol,
+        "host" => host,
+      }
+
+      @description["path"] = path unless path.nil?
+      @description
     end
   end
 end


### PR DESCRIPTION
# Goal

The goal of this PR is to allow support for accommodating multiple github orgs within the same context. For instance, we have agents that require authentication against different organizations during the same workflow

# How

The credential helper expects 4 environment variables that supply the necessary information to generate an access token: we just need to conditionally assign those values depending on the org.

When using the credential helper, the entrypoint is `exe/git-credential-github-app`, and `stdin` is expected to contain a newline-separated list of parameters:

```
# Example input

capability[]=authtype
capability[]=state
protocol=https
host=github.com
path=Shopify/infra-central.git # <--- This is important
wwwauth[]=Basic realm="GitHub"
```

We extract the org from the `path` entry, and for each `GITHUB_XYZ` env var, we first check if there is a `#{org.upcase}_GITHUB_XYZ` value. If there is, we use that one, otherwise fall back to `GITHUB_XYZ`

> [!IMPORTANT]
`path` will be empty UNLESS your git config sets `useHttpPath = true`. Without this, we will fallback to only considering `GITHUB_` prefixed env vars

# Miscellanea

- Originally `STDIN` was being parsed in `lib/github_authentication/git_credential_helper.rb`, but I needed to move that up to the CLI command in order to get the `org` value. All in all I think this is an improvement: I would prefer the boundary between program input occur as close to the system boundary as possible

# QA

- Add this to your git config
```
# Force https
[url "https://github.com/Shopify"]
  insteadOf = git@github.com:Shopify/
  insteadOf = ssh://git@github.com/Shopify
  insteadOf = git@github.com:shopify
  insteadOf = ssh://git@github.com:/shopify

# Setup the credential helper
[credential "https://github.com"]
  helper = # This disables any previously configured helper (the helper calls are additive, otherwise)
  helper = /PATH/TO/github-authentication/exe/git-credential-github-app
  useHttpPath = true
```

- Configure the environment variables in a way you want to test (e.g. org-specific, generic, mixture)

- Run a command that requires auth (`git clone`, `git pull`), etc. 
  - Note that due to token cache, you may already have a valid token and not trigger a request. In this case you can change `#{optional_prefix_}GITHUB_APP_CREDENTIAL_STORAGE_PATH`