### PR TITLE
Bump version to 1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ...
 
+### 1.3.3
+- Set JWT `iat` 60 seconds in the past to avoid clock drift issues with GitHub API
+
 ### 1.3.2
 - Add missing requires for active_support/cache to environment.rb
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    github-authentication (1.3.2)
+    github-authentication (1.3.3)
       activesupport (> 7)
       jwt (~> 2.2)
 

--- a/lib/github_authentication/version.rb
+++ b/lib/github_authentication/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GithubAuthentication
-  VERSION = "1.3.2"
+  VERSION = "1.3.3"
 end


### PR DESCRIPTION
Bump gem version to 1.3.3 for release. Includes the JWT iat clock drift fix from #40.

After merging, tag and publish:
```bash
git tag v1.3.3
git push origin v1.3.3
gem build github-authentication.gemspec
gem push github-authentication-1.3.3.gem
```