### PR TITLE
Bump version to 1.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ...
 
-### 1.3.3
+### 1.3.4
 - Set JWT `iat` 60 seconds in the past to avoid clock drift issues with GitHub API
 
 ### 1.3.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    github-authentication (1.3.3)
+    github-authentication (1.3.4)
       activesupport (> 7)
       jwt (~> 2.2)
 

--- a/lib/github_authentication/version.rb
+++ b/lib/github_authentication/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GithubAuthentication
-  VERSION = "1.3.3"
+  VERSION = "1.3.4"
 end


### PR DESCRIPTION
Re-release as 1.3.4 since the 1.3.3 tag was accidentally pushed before the version bump PR merged, causing ShipIt to deploy stale code.

After merging, tag and release:
```bash
git tag v1.3.4
git push origin v1.3.4
bundle exec rake release
```