### PR TITLE
Allow jwt 3.x (>= 2.2, < 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### Next
 
-...
+- Loosen `jwt` dependency constraint from `~> 2.2` to `>= 2.2, < 4` to allow `jwt` 3.x.
 
 ### 1.3.4
 - Set JWT `iat` 60 seconds in the past to avoid clock drift issues with GitHub API

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,12 +3,12 @@ PATH
   specs:
     github-authentication (1.3.4)
       activesupport (> 7)
-      jwt (~> 2.2)
+      jwt (>= 2.2, < 4)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (8.1.2)
+    activesupport (8.1.3)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
@@ -25,7 +25,7 @@ GEM
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     base64 (0.3.0)
-    bigdecimal (4.0.1)
+    bigdecimal (4.1.2)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crack (1.0.1)
@@ -35,8 +35,8 @@ GEM
     hashdiff (1.2.1)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    json (2.18.1)
-    jwt (2.10.2)
+    json (2.19.5)
+    jwt (3.2.0)
       base64
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)

--- a/github-authentication.gemspec
+++ b/github-authentication.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency("jwt", "~> 2.2")
+  spec.add_dependency("jwt", ">= 2.2", "< 4")
 
   spec.required_ruby_version = ">= 2.7.0"
 


### PR DESCRIPTION
Part of https://github.com/shop/issues/issues/46298

Loosens the `jwt` dependency from `~> 2.2` to `>= 2.2, < 4` so downstream consumers can pick up `jwt` 3.2.0 (which resolves HIGH-sev GHSA-c32j-vqhx-rx3x / CVE-2026-45363).

### Why this is safe

The only `JWT` API this gem uses is `JWT.encode(payload, key, "RS256")` in `lib/github_authentication/generator/app.rb`. That signature is unchanged between `jwt` 2.x and 3.x.

All `jwt` 3.0 breaking changes are on the decode/verify side:
- Mandatory signature verification before payload access
- Removed deprecated claim verification methods
- Stricter base64 decoding (RFC 4648)
- RSA-2048 minimum key size
- Removed HS512256 algorithm and rbnacl dependency

None of these affect this gem.

### Context

Blocking https://github.com/shop/world/pull/732803 (jwt CVE bump in `areas/platforms/trust-battery`).

Requested by @colin-strong 
Slack thread: https://shopify.enterprise.slack.com/archives/C09FSEMDKL0/p1779375258350209