### PR TITLE
Bump version to 1.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Next
 
+### 1.3.5
 - Loosen `jwt` dependency constraint from `~> 2.2` to `>= 2.2, < 4` to allow `jwt` 3.x.
 
 ### 1.3.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    github-authentication (1.3.4)
+    github-authentication (1.3.5)
       activesupport (> 7)
       jwt (>= 2.2, < 4)
 

--- a/lib/github_authentication/version.rb
+++ b/lib/github_authentication/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GithubAuthentication
-  VERSION = "1.3.4"
+  VERSION = "1.3.5"
 end


### PR DESCRIPTION
Chained to https://github.com/Shopify/github-authentication/pull/45

Part of https://github.com/shop/issues/issues/46298

Bump verion to 1.3.5